### PR TITLE
git-branch: shouldn't create branch called '-d' when deleting

### DIFF
--- a/git-commander.js
+++ b/git-commander.js
@@ -5,8 +5,9 @@ function gitCommander(repo) {
             'branch': function(options) {
                 if ( '-d' == options[0] ) {
                     repo.branchRemove(options[1]);
+                } else {
+                    repo.branch(options[0]);
                 }
-                repo.branch(options[0]);
             },
 
             'add': function(options) {


### PR DESCRIPTION
Modify branch() to don't call repo.branch() if '-d' option was given.
