### PR TITLE
Add 'git gc' to the list of supported commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ git rebase BRANCH_NAME
 
 git reset HASH
 
+git gc
+
 git cherry-pick HASH #just for demo
 
 git revert HASH  #just for demo


### PR DESCRIPTION
I saw in the talk that it's supported (and verified on http://io.git-init.ru/git-trainer/ that it is), but the readme doesn't mention it.
